### PR TITLE
Fix: `Ok` typo

### DIFF
--- a/yhttp/response.py
+++ b/yhttp/response.py
@@ -11,7 +11,7 @@ class Response:
     """
 
     #: HTTP Status code
-    status = '200 Ok'
+    status = '200 OK'
 
     #: Response encoding, ``None`` for binary
     charset = None


### PR DESCRIPTION
This PR fixes a typo in `yhttp/response.py`