### PR TITLE
Fix: ignore .flake8 bullshit about unassigned nonlocal keyword argume…

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
 [flake8]
-ignore = W503, F811
+# F824 https://github.com/PyCQA/flake8/pull/1975
+ignore = W503, F811, F824
 exclude = 
 	tests/test_multipart.py
 per-file-ignores =


### PR DESCRIPTION
…nt. PyCQA/flake8#1975