### PR TITLE
Feature: yhttp --version builtin CLI support

### DIFF
--- a/tests/test_builtincli_yhttp_version.py
+++ b/tests/test_builtincli_yhttp_version.py
@@ -1,0 +1,12 @@
+from bddcli import Application as CLIApplication, Given, stderr, stdout, status
+
+from yhttp.core import __version__
+
+
+def test_yhttp_version_cli():
+    cliapp = CLIApplication('yhttp', 'yhttp.core.main:app.climain')
+
+    with Given(cliapp, '--version'):
+        assert status == 0
+        assert stdout.strip() == __version__
+        assert stderr == ''


### PR DESCRIPTION
Closes #16

The `--version` flag was already implemented generically in `cli.py` and `main.py` already passes `__version__` to `Application`. This PR adds an end-to-end test confirming `yhttp --version` works correctly via the built-in CLI entry point (`yhttp.core.main:app.climain`).

**Files changed:**
- `tests/test_builtincli_yhttp_version.py` — new test using `bddcli` to verify `yhttp --version` exits 0 and prints the current version